### PR TITLE
group inventory_source options added to resolve #11

### DIFF
--- a/lib/tower_cli/resources/group.py
+++ b/lib/tower_cli/resources/group.py
@@ -34,12 +34,24 @@ class Resource(models.WritableResource):
     variables = models.Field(type=types.File('r'), required=False,
                              display=False)
 
+    # Basic options for the source
     @click.option('--credential', type=types.Related('credential'),
                   required=False,
                   help='The cloud credential to use.')
     @click.option('--source', type=click.Choice(INVENTORY_SOURCES),
                   default='manual',
                   help='The source to use for this group.')
+    @click.option('--source-regions', help='Regions for your cloud provider.')
+    # Options may not be valid for certain types of cloud servers
+    @click.option('--source-vars', help='Override variables found on source '
+                  'with variables defined in this field.')
+    @click.option('--overwrite', type=bool,
+                  help='Delete child groups and hosts not found in source.')
+    @click.option('--overwrite-vars', type=bool,
+                  help='Override vars in child groups and hosts with those '
+                  'from the external source.')
+    @click.option('--update-on-launch', type=bool, help='Refersh inventory '
+                  'data from its source each time a job is run.')
     def create(self, credential=None, source=None, **kwargs):
         """Create a group and, if necessary, modify the inventory source within
         the group.
@@ -75,6 +87,17 @@ class Resource(models.WritableResource):
     @click.option('--source', type=click.Choice(INVENTORY_SOURCES),
                   default='manual',
                   help='The source to use for this group.')
+    @click.option('--source-regions', help='Regions for your cloud provider.')
+    # Options may not be valid for certain types of cloud servers
+    @click.option('--source-vars', help='Override variables found on source '
+                  'with variables defined in this field.')
+    @click.option('--overwrite', type=bool,
+                  help='Delete child groups and hosts not found in source.')
+    @click.option('--overwrite-vars', type=bool,
+                  help='Override vars in child groups and hosts with those '
+                  'from the external source.')
+    @click.option('--update-on-launch', type=bool, help='Refersh inventory '
+                  'data from its source each time a job is run.')
     def modify(self, pk=None, credential=None, source=None, **kwargs):
         """Modify a group and, if necessary, the inventory source within
         the group.

--- a/lib/tower_cli/resources/inventory_source.py
+++ b/lib/tower_cli/resources/inventory_source.py
@@ -34,6 +34,16 @@ class Resource(models.MonitorableResource, models.WritableResource):
         type=click.Choice(['manual', 'ec2', 'rax', 'vmware',
                            'gce', 'azure', 'openstack']),
     )
+    source_regions = models.Field(required=False, display=False)
+    # Variables not shared by all cloud providers
+    source_vars = models.Field(required=False, display=False)
+    # Boolean variables
+    overwrite = models.Field(type=bool, required=False, display=False)
+    overwrite_vars = models.Field(type=bool, required=False, display=False)
+    update_on_launch = models.Field(type=bool, required=False, display=False)
+    # Only used if update_on_launch is used
+    update_cache_timeout = models.Field(type=int, required=False,
+                                        display=False)
 
     @click.argument('inventory_source', type=types.Related('inventory_source'))
     @click.option('--monitor', is_flag=True, default=False,


### PR DESCRIPTION
Added fields to the (hidden) resource inventory_source and options to the resource group. You can use the group create or group modify command to set these options. Those options include:
- source_regions
- source_vars
- overwrite
- overwrite_vars
- update_on_launch
- update_cache_timeout

Even with these added, not all possibilities are covered. For instance, for EC2 specifically we are not covering:
- instance fileters
- only group by

There are even more if you want to dig in the API, but unless someone specifically articulates a need for these, I'm not going to assume that they should be included at this point.

This survives manual testing. Since there is no logic added, there are no unit tests to add.

Note that if you create a group with the CLI and specify the region, it will not show up in the UI. However, if I specify a region in the UI and save it, it doesn't show in that case either. That might be my own server version, or it might be a UI bug.

I first set this PR to compare the ad_hoc branch as a base. That did not work, so I'm changing it to master in the main repo, and we will go from there.
